### PR TITLE
50 permitir utilização de link externo drive como material de apoio

### DIFF
--- a/src/pages/CreateLesson/index.jsx
+++ b/src/pages/CreateLesson/index.jsx
@@ -76,6 +76,15 @@ export const NewLessonScreen = () => {
     getCategories()
   }, [])
 
+  const validateExternAppendixLink = (value) => {
+    const tags = ['http', 'https', 'localhost']
+
+    for (const tag of tags)
+      if (value.includes(tag)) return true
+
+    return value.length == 0
+  }
+
   const setTitle = (e) => {
     setEstado({ ...estado, title: undefined })
     setFormValores({ ...formValores, title: cut(e?.target?.value ?? '', 64) })
@@ -83,7 +92,7 @@ export const NewLessonScreen = () => {
 
   const setExternAppendixLink = (e) => {
     setEstado({ ...estado, externAppendixLink: undefined })
-    setFormValores({ ...formValores, externAppendixLink: cut(e?.target?.value ?? '', 256) })
+    setFormValores({ ...formValores, externAppendixLink: cut(e?.target?.value?.trim() ?? '', 256) })
   }
 
   const setCategoryId = (e) => {
@@ -318,13 +327,13 @@ export const NewLessonScreen = () => {
                   </Col>
                   <Col xs={12} className="pl0">
                     <Form.Label className="w-100 mt-3">
-                      Link externo
+                      Link material de apoio
                       <Form.Control
                         className="input-title"
                         spellCheck={false}
                         required
                         type="text"
-                        placeholder=""
+                        placeholder="https://<url> ou vazio"
                         value={formValores.externAppendixLink}
                         onChange={setExternAppendixLink}
                         isValid={estado.externAppendixLink}
@@ -335,7 +344,7 @@ export const NewLessonScreen = () => {
                         onBlur={() =>
                           setEstado({
                             ...estado,
-                            externAppendixLink: true,
+                            externAppendixLink: validateExternAppendixLink(formValores.externAppendixLink),
                           })
                         }
                       />

--- a/src/pages/CreateLesson/index.jsx
+++ b/src/pages/CreateLesson/index.jsx
@@ -397,7 +397,7 @@ export const NewLessonScreen = () => {
                         : 'Nenhuma imagem selecionada'}
                     </span>
                   </Col>
-                  <Col xs={12} className="mt-3 pr0">
+                  <Col xs={12} className="mt-3 pr0" style={{display: 'none'}}>
                     <Form.Check
                       type="checkbox"
                       id="use-frame-as-banner-checkbox"
@@ -412,7 +412,7 @@ export const NewLessonScreen = () => {
                       checked={formValores.useBannerFromVideo}
                     />
                   </Col>
-                  <Col xs={12} className="mt-3 pr0">
+                  <Col xs={12} className="mt-3 pr0" style={{display: 'none'}}>
                     <label
                       htmlFor="input-files-video-ftc"
                       className="label-to-use-frame-as-banner-input"
@@ -420,7 +420,7 @@ export const NewLessonScreen = () => {
                       <span>Selecionar video</span>
                     </label>
                   </Col>
-                  <Col xs={12} className="file-input-span mb-3">
+                  <Col xs={12} className="file-input-span mb-3" style={{display: 'none'}}>
                     <span
                       className={`${!!estado.videos
                         ? 'ok'
@@ -437,7 +437,7 @@ export const NewLessonScreen = () => {
                         : 'Nenhum video selecionado'}
                     </span>
                   </Col>
-                  <Col xs={12} className="mt-1 mb-2 pr0">
+                  <Col xs={12} className="mt-1 mb-2 pr0" style={{display: 'none'}}>
                     <label
                       htmlFor="input-files-apc"
                       className="label-to-use-frame-as-banner-input"

--- a/src/pages/CreateLesson/index.jsx
+++ b/src/pages/CreateLesson/index.jsx
@@ -41,6 +41,7 @@ export const NewLessonScreen = () => {
       useBannerFromVideo: false,
       categoryId: null,
       apendices: [],
+      externAppendixLink: ''
     }
   }
 
@@ -51,6 +52,7 @@ export const NewLessonScreen = () => {
     files: undefined,
     content: undefined,
     videos: undefined,
+    externAppendixLink: undefined
   })
 
   const [formValores, setFormValores] = useState(resetValores())
@@ -79,6 +81,11 @@ export const NewLessonScreen = () => {
     setFormValores({ ...formValores, title: cut(e?.target?.value ?? '', 64) })
   }
 
+  const setExternAppendixLink = (e) => {
+    setEstado({ ...estado, externAppendixLink: undefined })
+    setFormValores({ ...formValores, externAppendixLink: cut(e?.target?.value ?? '', 256) })
+  }
+
   const setCategoryId = (e) => {
     setFormValores({ ...formValores, categoryId: e?.target?.value })
   }
@@ -96,6 +103,7 @@ export const NewLessonScreen = () => {
       videos:
         formValores.videos.length > 0 ||
         (formValores.files.length > 0 && !formValores.useBannerFromVideo),
+      externAppendixLink: true
     }
 
     setEstado({ ...estadoAux })
@@ -109,6 +117,7 @@ export const NewLessonScreen = () => {
     post.append('title', formValores.title)
     post.append('content', formValores.content)
     post.append('course', courseId)
+    post.append('extern_appendix_link', formValores.externAppendixLink)
 
     if (!formValores.useBannerFromVideo)
       post.append('banner', formValores.files[0])
@@ -302,6 +311,31 @@ export const NewLessonScreen = () => {
                           setEstado({
                             ...estado,
                             content: formValores.content.trim().length >= 3,
+                          })
+                        }
+                      />
+                    </Form.Label>
+                  </Col>
+                  <Col xs={12} className="pl0">
+                    <Form.Label className="w-100 mt-3">
+                      Link externo
+                      <Form.Control
+                        className="input-title"
+                        spellCheck={false}
+                        required
+                        type="text"
+                        placeholder=""
+                        value={formValores.externAppendixLink}
+                        onChange={setExternAppendixLink}
+                        isValid={estado.externAppendixLink}
+                        disabled={!editable}
+                        isInvalid={
+                          estado.externAppendixLink !== undefined ? !estado.externAppendixLink : undefined
+                        }
+                        onBlur={() =>
+                          setEstado({
+                            ...estado,
+                            externAppendixLink: true,
                           })
                         }
                       />

--- a/src/pages/EditLesson/index.jsx
+++ b/src/pages/EditLesson/index.jsx
@@ -440,7 +440,7 @@ export const EditLessonScreen = () => {
                                                 setFormValores({ ...formValores, useBannerFromVideo: e.target.checked })
                                             }}
                                             checked={formValores.useBannerFromVideo}
-                                            disabled={!editable}
+                                            disabled={!editable || true}
                                         />
                                     </Col>
                                     <Col xs={12} className='mt-3 pr0'>
@@ -455,11 +455,11 @@ export const EditLessonScreen = () => {
                                             </span>
                                         </Col>
                                     }
-                                    <Col xs={12} className="mt-1 mb-2 pr0">
+                                    <Col xs={12} className="mt-1 mb-2 pr0" style={{display: 'none'}}>
                                         <label
                                             htmlFor="input-files-apc"
                                             className="label-to-use-frame-as-banner-input"
-                                            style={{ cursor: editable ? 'pointer' : 'auto' }}
+                                            style={{ cursor: editable ? 'pointer' : 'auto'}}
                                         >
                                             <span>{formValores.apendices.length > 0 ? 'Trocar arquivo de apoio' : 'Selecionar arquivo de apoio'}</span>
                                         </label>

--- a/src/pages/EditLesson/index.jsx
+++ b/src/pages/EditLesson/index.jsx
@@ -48,7 +48,8 @@ export const EditLessonScreen = () => {
             useBannerFromVideo: false,
             course: null,
             caegoryId: null,
-            apendices: []
+            apendices: [],
+            externAppendixLink: ""
         };
     };
 
@@ -61,7 +62,8 @@ export const EditLessonScreen = () => {
         files: undefined,
         content: undefined,
         videos: undefined,
-        apendices: undefined
+        apendices: undefined,
+        externAppendixLink: undefined
     });
 
     const [formValores, setFormValores] = useState(resetValores());
@@ -82,9 +84,23 @@ export const EditLessonScreen = () => {
 
     useEffect(() => { if (id) refreshLesson() }, [id]);
 
+    const validateExternAppendixLink = (value) => {
+        const tags = ['http', 'https', 'localhost']
+
+        for (const tag of tags)
+            if (value.includes(tag)) return true
+
+        return value.length == 0
+    }
+
     const setTitle = (e) => {
         setEstado({ ...estado, title: undefined })
         setFormValores({ ...formValores, title: cut(e?.target?.value ?? "", 64) })
+    }
+
+    const setExternAppendixLink = (e) => {
+        setEstado({ ...estado, externAppendixLink: undefined })
+        setFormValores({ ...formValores, externAppendixLink: cut(e?.target?.value?.trim() ?? "", 256) })
     }
 
     const setContent = (e) => {
@@ -102,6 +118,7 @@ export const EditLessonScreen = () => {
             files: formValores.files.length > 0 || formValores.useBannerFromVideo,
             content: formValores.content.trim().length >= 3,
             videos: formValores.videos.length > 0 || (formValores.files.length > 0 && !formValores.useBannerFromVideo),
+            externAppendixLink: true
         };
 
         setEstado({ ...estadoAux });
@@ -114,6 +131,7 @@ export const EditLessonScreen = () => {
 
         post.append("title", formValores.title);
         post.append("content", formValores.content);
+        post.append("extern_appendix_link", formValores.externAppendixLink)
 
         if (!formValores.useBannerFromVideo && formValores.files.length && imageBeUpdated(formValores.files[0]))
             post.append("banner", formValores.files[0]);
@@ -217,6 +235,7 @@ export const EditLessonScreen = () => {
                 course: lesson.course,
                 categoryId: lesson.category.id,
                 apendices: !!lesson.appendix ? [lesson.appendix] : [],
+                externAppendixLink: lesson.extern_appendix_link
             })
             setLessonExists(true)
         } else setLessonExists(false)
@@ -368,6 +387,24 @@ export const EditLessonScreen = () => {
                                                 disabled={!editable}
                                                 isInvalid={estado.content !== undefined ? !estado.content : undefined}
                                                 onBlur={() => setEstado({ ...estado, content: formValores.content.trim().length >= 3 })}
+                                            />
+                                        </Form.Label>
+                                    </Col>
+                                    <Col xs={12} className="pl0">
+                                        <Form.Label className="w-100 mt-3">
+                                            Link material de apoio
+                                            <Form.Control
+                                                className="input-title"
+                                                spellCheck={false}
+                                                required
+                                                type="text"
+                                                placeholder="https://<url> ou vazio"
+                                                value={formValores.externAppendixLink}
+                                                onChange={setExternAppendixLink}
+                                                isValid={estado.externAppendixLink}
+                                                disabled={!editable}
+                                                isInvalid={estado.externAppendixLink !== undefined ? !estado.externAppendixLink : undefined}
+                                                onBlur={() => setEstado({ ...estado, externAppendixLink: validateExternAppendixLink(formValores.externAppendixLink) })}
                                             />
                                         </Form.Label>
                                     </Col>

--- a/src/pages/EditLesson/index.jsx
+++ b/src/pages/EditLesson/index.jsx
@@ -430,7 +430,7 @@ export const EditLessonScreen = () => {
                                             {formValores.files.length > 0 ? `${formValores.files.length} ${formValores.files.length > 1 ? 'imagens selecionadas' : 'imagem selecionada'}` : 'Nenhuma imagem selecionada'}
                                         </span>
                                     </Col>
-                                    <Col xs={12} className='mt-3 pr0'>
+                                    <Col xs={12} className='mt-3 pr0' style={{display: 'none'}}>
                                         <Form.Check
                                             type="checkbox"
                                             id='use-frame-as-banner-checkbox'
@@ -443,7 +443,7 @@ export const EditLessonScreen = () => {
                                             disabled={!editable || true}
                                         />
                                     </Col>
-                                    <Col xs={12} className='mt-3 pr0'>
+                                    <Col xs={12} className='mt-3 pr0' style={{display: 'none'}}>
                                         <label htmlFor="input-files-video-ftc" className='label-to-use-frame-as-banner-input' style={{ cursor: editable ? 'pointer' : 'auto' }}>
                                             <span>{formValores.videos.length > 0 ? 'Trocar video' : 'Selecionar video'}</span>
                                         </label>

--- a/src/pages/StudentLessonPage/index.js
+++ b/src/pages/StudentLessonPage/index.js
@@ -9,7 +9,7 @@ import ReactPlayer from 'react-player'
 import { toast } from 'react-toastify';
 import { UserTools } from '../../tools/user'
 import QuestionCourse from '../../components/QuestionCourse/question_course';
-import { HiDownload } from "react-icons/hi"
+import { HiDownload, HiOutlineExternalLink } from "react-icons/hi"
 import Navbar from 'react-bootstrap/Navbar'
 import Avatar from 'react-avatar'
 import './styles.css'
@@ -383,15 +383,19 @@ export const StudentLessonPage = () => {
           {logged && controle.enrolled &&
             <Row className='buttons'>
                 {
-                  <Button className='' style={{ 'marginRight': '1rem', fontWeight: '600', backgroundColor: '#0E6216', borderColor: '#0E6216', borderRadius: '10px', width: '230px', height: '39px'}} onClick={() => anotar()}>Fazer Anotação <FontAwesomeIcon icon={faPen} /></Button>
+                  <Button className='btn-resources' style={{ marginRight: '1rem', fontWeight: '600', backgroundColor: '#0E6216', borderColor: '#0E6216', borderRadius: '10px', width: '230px', height: '39px'}} onClick={() => anotar()}>Fazer Anotação <FontAwesomeIcon icon={faPen} /></Button>
                 }
                 {
                   !!lesson.appendix &&
-                  <Button className='btn-apoio' onClick={() => window.open(lesson.appendix, '_blank')} style={{marginRight: '1rem', fontWeight: '600', backgroundColor: '#0E6216', borderColor: '#0E6216', borderRadius: '10px', width: '230px', height: '39px'}}>Arquivo de apoio <HiDownload style={{ fontSize: '20px' }} /> </Button>
+                  <Button className='btn-resources' onClick={() => window.open(lesson.appendix, '_blank')} style={{marginRight: '1rem', fontWeight: '600', backgroundColor: '#0E6216', borderColor: '#0E6216', borderRadius: '10px', width: '230px', height: '39px'}}>Arquivo de apoio <HiDownload style={{ fontSize: '20px' }} /> </Button>
+                }
+                {
+                  !!lesson.extern_appendix_link.trim().length &&
+                  <Button className='btn-resources' onClick={() => window.open(lesson.extern_appendix_link, '_blank')} style={{marginRight: '1rem', fontWeight: '600', backgroundColor: '#0E6216', borderColor: '#0E6216', borderRadius: '10px', width: '230px', height: '39px'}}>Material de apoio <HiOutlineExternalLink style={{ fontSize: '20px' }} /> </Button>
                 }
                 {
                   !lesson.video && !videoPlayer.completed && 
-                  <Button className='btn-complete-lesson' onClick={completeStudentLesson} style={{fontWeight: '600', backgroundColor: '#0E6216', borderColor: '#0E6216', borderRadius: '10px', width: '230px', height: '39px'}}>Concluir aula </Button>
+                  <Button className='btn-resources' onClick={completeStudentLesson} style={{marginRight: '1rem', fontWeight: '600', backgroundColor: '#0E6216', borderColor: '#0E6216', borderRadius: '10px', width: '230px', height: '39px'}}>Concluir aula </Button>
                 }
             </Row>
           }

--- a/src/pages/StudentLessonPage/styles.css
+++ b/src/pages/StudentLessonPage/styles.css
@@ -32,11 +32,12 @@
   margin-left: 1px;
 }
 
+.container-student-lesson-page .flag-completed-lesson, .container-student-lesson-page .buttons .btn-resources {
+  margin-top: 15px;
+}
+
 @media (max-width:991.98px){
   .container-student-lesson-page .flag-completed-lesson, .container-student-lesson-page .buttons{
     flex-direction: column;
-  }
-  .container-student-lesson-page .flag-completed-lesson, .container-student-lesson-page .buttons .btn-apoio, .container-student-lesson-page .buttons .btn-complete-lesson{
-    margin-top: 15px;
   }
 }


### PR DESCRIPTION
Conclui #50: 
- Permite adicionar link externo para material de apoio ao criar/editar aula.
- Desabilita upload de arquivo como material de apoio ao criar/editar aula.
- Desabilita upload de video ao criar/editar aula.
- Adiciona botão na página de aula para abrir uma nova aba para o link de material de apoio.
- Outros ajustes pequenos.

![Screenshot from 2024-03-17 18-51-48](https://github.com/Plataforma-29-de-abril/29-april-frontend/assets/76932488/93879f77-0111-45c9-b0a7-70d3c29eb368)
![Screenshot from 2024-03-17 18-49-57](https://github.com/Plataforma-29-de-abril/29-april-frontend/assets/76932488/2ff1241a-87b8-45be-9e48-fa8996f6e266)
