### PR TITLE
Paginação em Bookmarks e Meus cursos

### DIFF
--- a/src/pages/ProfessorCourses/index.jsx
+++ b/src/pages/ProfessorCourses/index.jsx
@@ -44,8 +44,8 @@ const ProfessorCoursesPage = () => {
                                 : <Pagination.Prev disabled onClick={() => activePage > 1 && setActivePage((prevState) => prevState - 1)} />
                             }
                             {items}
-                            {isFetched ? <Pagination.Next onClick={() => activePage < 3 && setActivePage((prevState) => prevState + 1)} />
-                                : <Pagination.Next disabled onClick={() => activePage < 3 && setActivePage((prevState) => prevState + 1)} />}
+                            {isFetched ? <Pagination.Next onClick={() => activePage < amountPages && setActivePage((prevState) => prevState + 1)} />
+                                : <Pagination.Next disabled onClick={() => activePage < amountPages && setActivePage((prevState) => prevState + 1)} />}
                         </>
                     )}
                 </Pagination>

--- a/src/pages/StudentCourses/student_courses.jsx
+++ b/src/pages/StudentCourses/student_courses.jsx
@@ -47,8 +47,8 @@ const StudentCoursesPage = () => {
                                 : <Pagination.Prev disabled onClick={() => activePage > 1 && setActivePage((prevState) => prevState - 1)} />
                             }
                             {items}
-                            {isFetched ? <Pagination.Next onClick={() => activePage < 3 && setActivePage((prevState) => prevState + 1)} />
-                                : <Pagination.Next disabled onClick={() => activePage < 3 && setActivePage((prevState) => prevState + 1)} />}
+                            {isFetched ? <Pagination.Next onClick={() => activePage < amountPages && setActivePage((prevState) => prevState + 1)} />
+                                : <Pagination.Next disabled onClick={() => activePage < amountPages && setActivePage((prevState) => prevState + 1)} />}
                         </>
                     )}
                 </Pagination>


### PR DESCRIPTION
Alterações:

- Exclusão da paginação na tela de `Bookmarks` e implementação de uma listagem geral. Para isto, são feitas requisições das páginas que contém cursos favoritados pelo usuário, com base no campo `next`.

- Conserto da paginação em `Meus cursos`, tanto em `Alunos` quanto em `Professores`, desabilitando o botão de próximo ao atingir-se o número máximo de páginas ditado por `amountPages`.