### PR TITLE
Muda requisições HTTP por bookmarks para HTTPS

### DIFF
--- a/src/pages/BookmarksPage/bookmark_page.jsx
+++ b/src/pages/BookmarksPage/bookmark_page.jsx
@@ -53,8 +53,8 @@ const BookmarksPage = () => {
 
                     url = jsonData.next
 
-                    if (url.includes("http")) {
-                        url = url.replace("http", "https")
+                    if (url.includes("http:")) {
+                        url = url.replace("http:", "https:")
                     }
                     //AUTH_DEBUG && console.log("AuthAPI::getBookmarks(): ", data);
                 } else throw new Error("Error on getBookmarks()");

--- a/src/pages/BookmarksPage/bookmark_page.jsx
+++ b/src/pages/BookmarksPage/bookmark_page.jsx
@@ -39,6 +39,7 @@ const BookmarksPage = () => {
             var data = {"results" : []}
 
             while(true) {
+                
                 const response = await fetch(url, options);
 
                 if (response.ok) {
@@ -51,6 +52,10 @@ const BookmarksPage = () => {
                     }
 
                     url = jsonData.next
+
+                    if (url.includes("http")) {
+                        url = url.replace("http", "https")
+                    }
                     //AUTH_DEBUG && console.log("AuthAPI::getBookmarks(): ", data);
                 } else throw new Error("Error on getBookmarks()");
             }


### PR DESCRIPTION
Alteração:

- Muda requisições HTTP por páginas de `Bookmark` para HTTPS, por causa de problemas com o CORS.